### PR TITLE
Make Pixie a more perfect Scratch clone

### DIFF
--- a/assets/pixie.css
+++ b/assets/pixie.css
@@ -22,6 +22,26 @@ button::-moz-focus-inner {
   border: 0;
 }
 
+body ::-webkit-scrollbar {
+    width: 13px; /* CSS decides whether to apply width/height via magic */
+    height:13px;
+}
+body ::-webkit-scrollbar-track {
+    background:rgba(0,0,0,0.085);
+    border-radius: 99px;
+    border:2px solid transparent;
+    background-clip: content-box;
+}
+body ::-webkit-scrollbar-thumb {
+    border-radius: 99px;
+    background:#6E6F72;
+    border:2px solid transparent;
+    background-clip: content-box;
+}
+body ::-webkit-scrollbar-corner {
+  display:none;
+}
+
 
 /* Main objects */
 
@@ -200,7 +220,7 @@ button::-moz-focus-inner {
 .mouse-coords {
   position: absolute;
   left: 386px;
-  top: 401px;
+  top: 402px;
   width: 87px;
   height: 14px;
   overflow: hidden;
@@ -330,6 +350,7 @@ button::-moz-focus-inner {
   top: 2px;
   left: 50px;
   width: 350px;
+  padding-bottom:1px;
 }
 .project-author {
   position: absolute;
@@ -657,7 +678,7 @@ button::-moz-focus-inner {
 }
 .tab {
   display: inline-block;
-  padding: 0 13px 2px 11px;
+  padding: 1px 14px 2px 11.5px;
   margin: 0;
   height: 24px;
   font: inherit;
@@ -665,7 +686,7 @@ button::-moz-focus-inner {
   border-bottom: 0;
   border-radius: 7px 7px 0 0;
   background: #f2f2f2;
-  box-shadow: inset 0 -3px 3px -3px #d1d2d3;
+  box-shadow: inset 0 -3px 2px -1.5px #d1d2d3;
   position: relative;
   color: #8f9193;
   box-sizing: content-box;
@@ -707,9 +728,9 @@ button::-moz-focus-inner {
 }
 .palette-buttons {
   width: 202px;
-  padding: 8px 7px 8px 0;
+  padding: 7px 7px 8px 0;
   top: 0;
-  height: 88px;
+  height: 104px;
 }
 .palette-buttons::before {
   content: '';
@@ -725,7 +746,7 @@ button::-moz-focus-inner {
   float: left;
   box-sizing: border-box;
   width: 99px;
-  height: 17px;
+  height: 20px;
   padding: 0 0 0 8px;
   border: 0;
   background: 0;
@@ -739,6 +760,7 @@ button::-moz-focus-inner {
 .palette-button div {
   border-left: 7px solid;
   padding-left: 4px;
+  padding-top:1px;
   width: 80px;
 }
 .palette-button strong {
@@ -758,7 +780,7 @@ button::-moz-focus-inner {
 }
 .palette-contents {
   width: 209px;
-  top: 104px;
+  top: 119px;
   bottom: 0;
 }
 .palette-label {


### PR DESCRIPTION
This branch has slight modifications to make Pixie match Scratch more closely.

**Changes:**
- Tabs (scripts, costumes, sounds) have slightly modified padding to better match Scratch
- Palette selector buttons are taller to match Scratch exactly
- Added Scratch-like scroll bars within the editor (woo!)


![output_n24mrl](https://cloud.githubusercontent.com/assets/5458180/14162403/9847e958-f6b9-11e5-8f00-cf320c3b4e31.gif)
